### PR TITLE
Improve OCR accuracy

### DIFF
--- a/TSW2_Controller/FormMain.cs
+++ b/TSW2_Controller/FormMain.cs
@@ -121,6 +121,8 @@ namespace TSW2_Controller
             }
             #endregion
 
+            TCengine.DefaultPageSegMode = PageSegMode.SingleLine;
+
             lbl_originalResult.Text = "";
             lbl_alternativeResult.Text = "";
             lbl_updateAvailable.Text = "";


### PR DESCRIPTION
Since Tesseract is only used to read single line sim value, according to my experience, specifying single line page seg mode can greatly increase accuracy in text detection. OCR scan time is reduced too because Tesseract no longer has to determine the page.